### PR TITLE
Add weight/dimension tier 2 & 3 surcharge fields to rate.quote

### DIFF
--- a/_posts/2014-07-30-rate.md
+++ b/_posts/2014-07-30-rate.md
@@ -536,6 +536,62 @@ An array of enabled shipping methods.
     </td>
 </tr>
 <tr>
+    <th>weight_surcharge_tier2</th>
+    <td>
+        <pre><code>{ "weight_surcharge_tier2" : "40.00" }</code></pre>
+        Weight surcharge tier 2 (e.g. GLS Overweight 2).
+    </td>
+</tr>
+<tr>
+    <th>weight_surcharge_tier2_currency</th>
+    <td>
+        <pre><code>{ "weight_surcharge_tier2_currency" : "USD" }</code></pre>
+        Weight surcharge tier 2 currency. An ISO 4217 alphabetic code.
+    </td>
+</tr>
+<tr>
+    <th>weight_surcharge_tier3</th>
+    <td>
+        <pre><code>{ "weight_surcharge_tier3" : "200.00" }</code></pre>
+        Weight surcharge tier 3 (e.g. GLS Overweight 3).
+    </td>
+</tr>
+<tr>
+    <th>weight_surcharge_tier3_currency</th>
+    <td>
+        <pre><code>{ "weight_surcharge_tier3_currency" : "USD" }</code></pre>
+        Weight surcharge tier 3 currency. An ISO 4217 alphabetic code.
+    </td>
+</tr>
+<tr>
+    <th>dimension_surcharge_tier2</th>
+    <td>
+        <pre><code>{ "dimension_surcharge_tier2" : "65.50" }</code></pre>
+        Dimension surcharge tier 2 (e.g. GLS Special Handling 1).
+    </td>
+</tr>
+<tr>
+    <th>dimension_surcharge_tier2_currency</th>
+    <td>
+        <pre><code>{ "dimension_surcharge_tier2_currency" : "USD" }</code></pre>
+        Dimension surcharge tier 2 currency. An ISO 4217 alphabetic code.
+    </td>
+</tr>
+<tr>
+    <th>dimension_surcharge_tier3</th>
+    <td>
+        <pre><code>{ "dimension_surcharge_tier3" : "91.00" }</code></pre>
+        Dimension surcharge tier 3 (e.g. GLS Special Handling 2).
+    </td>
+</tr>
+<tr>
+    <th>dimension_surcharge_tier3_currency</th>
+    <td>
+        <pre><code>{ "dimension_surcharge_tier3_currency" : "USD" }</code></pre>
+        Dimension surcharge tier 3 currency. An ISO 4217 alphabetic code.
+    </td>
+</tr>
+<tr>
     <th>demand_surcharge</th>
     <td>
         <pre><code>{ "demand_surcharge" : "4.00" }</code></pre>


### PR DESCRIPTION
## Summary

- Add `weight_surcharge_tier2`, `weight_surcharge_tier3`, `dimension_surcharge_tier2`, `dimension_surcharge_tier3` (and their `_currency` variants) to the Rate Properties table in the `rate.quote` API docs
- These new fields support GLS Overweight (OW2/OW3) and Special Handling (SH1/SH2) surcharges

Refs DEV-2896