### PR TITLE
Document the inventory:hold_changed webhook topic

### DIFF
--- a/_posts/2015-06-12-topics.md
+++ b/_posts/2015-06-12-topics.md
@@ -1030,6 +1030,7 @@ include the `qty_adjust` key, but rather only the absolute values.
 {
     "topic" : "inventory:hold_changed",
     "message" : {
+        "merchant_code" : "base",
         "transaction_id" : "9f1c4b6a2d7e40c8b3a5f6091d2e8c74",
         "chunk_index" : 1,
         "chunk_count" : 1,
@@ -1092,6 +1093,7 @@ are listed in `hold_ids`, sorted ascending.
 
 | Field | Description |
 | ----- | ----------- |
+| `merchant_code` | Code of the merchant whose inventory hold changed. |
 | `transaction_id` | Random identifier shared by every message produced by one committed operation, per merchant. |
 | `chunk_index`, `chunk_count` | 1-based position within that operation's messages. Large operations are split so a single message carries at most 500 hold ids. Reconstruct the logical order from these fields rather than from delivery order, which is not guaranteed across retries. |
 | `action` | `placed` or `released`. |

--- a/_posts/2015-06-12-topics.md
+++ b/_posts/2015-06-12-topics.md
@@ -20,6 +20,7 @@ order: 200
 * [import:created](#import_created)
 * [import:completed](#import_completed)
 * [inventory:adjusted](#inventory_adjusted)
+* [inventory:hold_changed](#inventory_hold_changed)
 * [order:created](#order_created)
 * [order:canceled](#order_canceled)
 * [order:items_updated](#order_items_updated)
@@ -1020,6 +1021,94 @@ Event Payloads
 Stock adjustments will be included when a Bill of Material component is adjusted which affects a related
 products' Virtual Inventory. Stock adjustments for changes invoked because of Virtual Inventory will not
 include the `qty_adjust` key, but rather only the absolute values.
+
+<h3 id="inventory_hold_changed">
+    inventory:hold_changed
+</h3>
+
+```json
+{
+    "topic" : "inventory:hold_changed",
+    "message" : {
+        "transaction_id" : "9f1c4b6a2d7e40c8b3a5f6091d2e8c74",
+        "chunk_index" : 1,
+        "chunk_count" : 1,
+        "changes" : [
+            {
+                "action" : "placed",
+                "status" : "active",
+                "scope_type" : "lot",
+                "product_id" : 7,
+                "sku" : "sku123",
+                "external_id" : null,
+                "warehouse_id" : null,
+                "lot_id" : 41,
+                "lot_number" : "2024-05-01",
+                "reason" : {
+                    "code" : "damaged",
+                    "label" : "Damaged",
+                    "display_group" : "Hold"
+                },
+                "hold_reason_code" : "damaged",
+                "parent_hold_id" : null,
+                "release_cause" : null,
+                "hold_ids" : [ 5012 ]
+            },
+            {
+                "action" : "placed",
+                "status" : "active",
+                "scope_type" : "location",
+                "product_id" : 7,
+                "sku" : "sku123",
+                "external_id" : null,
+                "warehouse_id" : 1,
+                "lot_id" : 41,
+                "lot_number" : "2024-05-01",
+                "reason" : {
+                    "code" : "damaged",
+                    "label" : "Damaged",
+                    "display_group" : "Hold"
+                },
+                "hold_reason_code" : "damaged",
+                "parent_hold_id" : 5012,
+                "release_cause" : null,
+                "hold_ids" : [ 5013, 5014, 5015 ]
+            }
+        ],
+        "webhook_increment_id" : 1,
+        "event_timestamp" : "2021-12-07T16:08:15+00:00"
+    }
+}
+```
+
+Sent when inventory holds are placed or released. An inventory hold freezes inventory in place so that it is
+excluded from the available quantity; it is not a quantity movement, so this topic reports only lifecycle
+transitions. Use [inventory:adjusted](#inventory_adjusted) and the inventory polling APIs for quantities.
+
+Each `changes` entry aggregates every hold that made the same transition at the same
+product / warehouse / lot / reason / scope, so one operation that holds many locations produces one change
+rather than one per location. Individual slot identity is deliberately not exposed: the affected audit rows
+are listed in `hold_ids`, sorted ascending.
+
+| Field | Description |
+| ----- | ----------- |
+| `transaction_id` | Random identifier shared by every message produced by one committed operation, per merchant. |
+| `chunk_index`, `chunk_count` | 1-based position within that operation's messages. Large operations are split so a single message carries at most 500 hold ids. Reconstruct the logical order from these fields rather than from delivery order, which is not guaranteed across retries. |
+| `action` | `placed` or `released`. |
+| `status` | Absolute state after the transition: `active` or `released`. |
+| `scope_type` | `location` for a hold on a specific location, or `lot` for the lot-wide sentinel that keeps a whole lot held. |
+| `product_id`, `sku`, `external_id` | The product the hold applies to. |
+| `warehouse_id` | The warehouse, or `null` for a `lot` scope hold, which spans warehouses. |
+| `lot_id`, `lot_number` | The lot, or `null` when the inventory is not lot tracked. |
+| `reason` | The selected hold reason: its `code`, display `label`, and `display_group`. |
+| `hold_reason_code` | The parent reason code the selected reason rolls up to. Equal to `reason.code` when the reason has no parent. |
+| `parent_hold_id` | The persisted parent hold, or `null`. A lot sentinel is the parent of the location holds it spreads to. This is durable lineage, not "created by this operation" — group by `transaction_id` for the latter. |
+| `release_cause` | Present on `released` changes: `explicit`, `drain`, `reconcile`, or `superseded`. `null` for `placed`. |
+| `hold_ids` | Sorted, de-duplicated ids of the hold audit rows that made this transition. |
+
+A hold that is both placed and released within one operation produces two ordered changes. Changes are never
+merged across different parent holds or different release causes, so each entry describes one unambiguous
+transition.
 
 <h3 id="shipment_packed">
     shipment:packed


### PR DESCRIPTION
Documents the new `inventory:hold_changed` webhook topic on the Topics reference page.

An inventory hold freezes inventory in place so that it is excluded from the available quantity. Until now its lifecycle had no public event: quantity-carrying placements were only visible through `inventory:adjusted`, and state-only transitions — empty placement, empty release, lot sentinel lifecycle, relocation re-mint, superseded release — were not observable at all.

**Added to `_posts/2015-06-12-topics.md`**

- Table-of-contents entry after `inventory:adjusted`.
- A payload example showing both scopes: a lot sentinel (`warehouse_id: null`) and the aggregated location holds parented to it.
- Prose describing the topic boundary — lifecycle only, no quantities, no slot identity — pointing readers at `inventory:adjusted` and the polling APIs for quantities.
- A field table covering the aggregation grain, `transaction_id` / `chunk_index` / `chunk_count` semantics (at most 500 hold ids per message, logical order reconstructed from the metadata rather than from delivery order), `parent_hold_id` as durable lineage, and the `release_cause` values.

Refs DEV-3110